### PR TITLE
Feature/1/input filename for download

### DIFF
--- a/src/components/App/GenerateImage/Meme.js
+++ b/src/components/App/GenerateImage/Meme.js
@@ -41,6 +41,11 @@ const Close = styled.div`
     cursor: pointer;
 `;
 
+function getFilename() {
+    var filename = document.getElementById("filenameInput").value + '.png';
+    return filename;
+}
+
 export const Meme = ({ path, close }) => {
     return (
         <Wrapper onClick={close}>
@@ -48,7 +53,7 @@ export const Meme = ({ path, close }) => {
                 <MemeTitle as="h4" fsize="1.5" margin="0 0 2rem">
                     Click the image to download
                 </MemeTitle>
-                <a href={path} download="my-awesome-meme.png">
+                <a href={path} download={getFilename()}>
                     <Image src={path} alt="Generated Meme" />
                 </a>
             </InnerContainer>

--- a/src/components/App/GenerateImage/index.js
+++ b/src/components/App/GenerateImage/index.js
@@ -15,7 +15,7 @@ export const GenerateImage = () => {
 
 
     // Methods
-    const generateMeme = () => {
+    function generateMeme() {
         htmlToImage
             .toPng(document.getElementById('active-image'))
             .then(function (dataUrl) {
@@ -27,7 +27,7 @@ export const GenerateImage = () => {
             .catch(function (error) {
                 console.error('We have a problem:', error);
             });
-        }
+    }
 
 
     const resetMeme = () => {
@@ -37,6 +37,17 @@ export const GenerateImage = () => {
     const closeMeme = () => {
         setImage(null);
     };
+
+    const validateInput = () => {
+        // Validate that the filename given is not empty and contains 15 characters or less
+        var filenameInput = document.getElementById('filenameInput').value;
+        if (filenameInput !== "" && filenameInput.length <= 15) {
+            generateMeme();
+        }
+        else {
+            alert("Filename cannot be empty or above 15 characters.");
+        }
+    }
 
     
 
@@ -50,7 +61,7 @@ export const GenerateImage = () => {
             <Button
                 primary
                 margin="0 1rem 1rem 0"
-                handleClick={generateMeme}
+                handleClick={validateInput}
                 isDisabled={!meme.state.imageSelected}
             >
                 Generate a new MEME

--- a/src/components/App/TextImage/index.js
+++ b/src/components/App/TextImage/index.js
@@ -174,7 +174,6 @@ const TextImage = () => {
                 </Label>
                 <Input
                     intype="text"
-                    max="15"
                     id="filenameInput"
                     onChange={handleFilename}
                     value={meme.state.filename}

--- a/src/components/App/TextImage/index.js
+++ b/src/components/App/TextImage/index.js
@@ -49,6 +49,10 @@ const TextImage = () => {
         meme.dispatch({ type: 'TEXT_OUTSIDE' });
     };
 
+    const handleFilename = e => {
+        meme.dispatch({ type: 'UPDATE_FILENAME', payload: e.target.value });
+    };
+
     // Render
     return (
         <TextWrapper className={meme.state.imageSelected ? 'active' : ''}>
@@ -161,6 +165,22 @@ const TextImage = () => {
             </WrapInput>
 
             <TextLegenda>* Both of the above texts are optional.</TextLegenda>
+
+            {/* Filename input */}
+            <WrapInput>
+                <br />
+                <Label primary htmlFor="filenameInput">
+                    Filename
+                </Label>
+                <Input
+                    intype="text"
+                    max="15"
+                    id="filenameInput"
+                    onChange={handleFilename}
+                    value={meme.state.filename}
+                    disabled={!meme.state.imageSelected}
+                />
+            </WrapInput>
         </TextWrapper>
     );
 };

--- a/src/context/MemeContext.js
+++ b/src/context/MemeContext.js
@@ -9,6 +9,7 @@ const initialState = {
     bottomTextSize: 2,
     textOutside: false,
     imageSelected: null,
+    filename: 'my-awesome-meme'
 };
 
 const MemeContext = createContext(initialState);
@@ -57,6 +58,11 @@ const StateProvider = ({ children }) => {
                 return {
                     ...state,
                     imageSelected: action.payload,
+                };
+            case 'UPDATE_FILENAME':
+                return {
+                    ...state,
+                    filename: action.payload,
                 };
             case 'RESET_MEME':
                 return initialState;


### PR DESCRIPTION
Added text input for desired Filename to the home screen, below the other text inputs.
Default input for Filename is set to "my-awesome-meme", and is overridable.
When clicking "Generate a new MEME", it validates the text field to check for empty input and more than 15 characters, sending an alert if so. 
If passed and image is clicked to download, the name of the downloaded meme is now as entered by the user with .png extension.

