### PR TITLE
Bug/14/app crashes after cancelled image selection

### DIFF
--- a/src/components/App/UploadImage/index.js
+++ b/src/components/App/UploadImage/index.js
@@ -21,16 +21,6 @@ const UpdateImage = () => {
         firstInput.select();
     }, [meme.state.imageSelected]);
 
-    // Methods
-    // const handleFocusBack= () => {
-    // console.log('focus-back');
-    // window.removeEventListener('focus', this.handleFocusBack);
-    // }
-    // const clickedFileInput= () =>{
-    // window.addEventListener('focus', this.handleFocusBack);
-    // console.log('has been clicked')
-    // }
-
     const handleLocalImage = e => {
         const img = e.target.files[0];
         const newImage = {

--- a/src/components/App/UploadImage/index.js
+++ b/src/components/App/UploadImage/index.js
@@ -29,8 +29,14 @@ const UpdateImage = () => {
             path: URL.createObjectURL(img),
         };
 
+        //newImage.name? img.name: "default";
+
+        if (!meme.state.imageSelected) {
             meme.dispatch({ type: 'IMAGE_SELECTED', payload: newImage });
-    };
+        }
+        };
+   
+
 
     // Render
     let label, caption;
@@ -47,7 +53,7 @@ const UpdateImage = () => {
             <ImageLabel active={meme.state.imageSelected !== null}>
                 {label}
             </ImageLabel>
-            <ImageInput  onChange={handleLocalImage} onClick={(e)=> e.currentTarget.value = null}/>
+            <ImageInput  onChange={handleLocalImage}  onClick={e=> e.currentTarget.value = null}/>
             {caption}
         </ImageWrapper>
     );

--- a/src/components/App/UploadImage/index.js
+++ b/src/components/App/UploadImage/index.js
@@ -1,11 +1,13 @@
 import React, { useContext, useEffect } from 'react';
 import { MemeContext } from '../../../context/MemeContext';
+
 import ImageWrapper from './ImageWrapper';
 import ImageLabel from './ImageLabel';
 import ImageInput from './ImageInput';
 import ImageCaption from './ImageCaption';
 import ActiveImage from './ActiveImage';
 import NoImage from './NoImage';
+
 
 const UpdateImage = () => {
     // Global state
@@ -20,6 +22,15 @@ const UpdateImage = () => {
     }, [meme.state.imageSelected]);
 
     // Methods
+    // const handleFocusBack= () => {
+    // console.log('focus-back');
+    // window.removeEventListener('focus', this.handleFocusBack);
+    // }
+    // const clickedFileInput= () =>{
+    // window.addEventListener('focus', this.handleFocusBack);
+    // console.log('has been clicked')
+    // }
+
     const handleLocalImage = e => {
         const img = e.target.files[0];
         const newImage = {
@@ -28,9 +39,7 @@ const UpdateImage = () => {
             path: URL.createObjectURL(img),
         };
 
-        if (!meme.state.imageSelected) {
             meme.dispatch({ type: 'IMAGE_SELECTED', payload: newImage });
-        }
     };
 
     // Render
@@ -40,6 +49,7 @@ const UpdateImage = () => {
         caption = <ImageCaption />;
     } else {
         label = <NoImage>Upload an image from your computer</NoImage>;
+       
     }
 
     return (
@@ -47,7 +57,7 @@ const UpdateImage = () => {
             <ImageLabel active={meme.state.imageSelected !== null}>
                 {label}
             </ImageLabel>
-            <ImageInput onChange={handleLocalImage} />
+            <ImageInput  onChange={handleLocalImage} onClick={(e)=> e.currentTarget.value = null}/>
             {caption}
         </ImageWrapper>
     );


### PR DESCRIPTION
If the user selects an image then clicks the image upload a second time to be on the file select menu, if they then cancel out of the file select menu the app crashes. This happens only with the app running locally on the live version [The MEME Generator (pd-meme-generator.netlify.app)](https://pd-meme-generator.netlify.app/) this error does not occur

To recreate issue run the app locally with npm start

1.click on image select and choose a file to upload

2. click on the image to bring up the file select again

3. cancel out of the file select

The error should be shown in the console and the rest of the app should freeze